### PR TITLE
Add cluster configuration for cli-production in datacenter-east

### DIFF
--- a/sites/datacenter-east/mce-tenant-cluster/mce-prod/mce-main/ocp4-cli-production.yaml
+++ b/sites/datacenter-east/mce-tenant-cluster/mce-prod/mce-main/ocp4-cli-production.yaml
@@ -1,0 +1,34 @@
+clusterName: cli-production
+platform: agent
+nodePool:
+- name: cli-production-nodepool
+  replicas: 5
+  labels:
+    allowDeletion: false
+    minReplicas: '4'
+    maxReplicas: '6'
+  agentLabelSelector:
+    nodeLabelKey: infraenv
+    nodeLabelValue: portworks-baremetal
+  configs:
+  - nm-conf-cli-production
+  - worker-kubeconfig
+  - portworks-storage-config
+mcConfig:
+- nm-conf-cli-production
+- worker-kubeconfig
+- portworks-storage-config
+idms:
+  mirrors:
+  - source: registry.redhat.io
+    mirrors:
+    - registry.internal.company.com/redhat
+  - source: quay.io
+    mirrors:
+    - registry.internal.company.com/quay
+  - source: registry.access.redhat.com
+    mirrors:
+    - registry.internal.company.com/access-redhat
+  - source: portworks.io
+    mirrors:
+    - registry.internal.company.com/portworks


### PR DESCRIPTION
Cluster: cli-production
Site: datacenter-east
Environment: prod
Nodes: 5
Flavor: portworks